### PR TITLE
feat: utilising API response in-app

### DIFF
--- a/src/components/CardPopup.jsx
+++ b/src/components/CardPopup.jsx
@@ -16,6 +16,8 @@ import teamValues from "../utils/Values";
 import { fullUsersUrl } from "../utils/ApiPaths";
 
 export default function PopUp(props) {
+  const userData = JSON.parse(localStorage.getItem("loggedInUser"));
+
   // Set default values of formData
   const [formData, setFormData] = useState({
     recipient: "",
@@ -104,7 +106,7 @@ export default function PopUp(props) {
     }));
   };
 
-// TODO: drop-down menus are shifting elements on screen upon click, check styling for these to resolve
+  // TODO: drop-down menus are shifting elements on screen upon click, check styling for these to resolve
 
   return (
     <div className="modal">
@@ -134,15 +136,25 @@ export default function PopUp(props) {
                     variant="outlined"
                     onChange={handleChange}
                   >
-                    {fullUsers.map((user) => (
-                      <MenuItem
-                        className="cardFormValues"
-                        key={user._id}
-                        value={user._id}
-                      >
-                        {user.name.first} {user.name.last}
-                      </MenuItem>
-                    ))}
+                    {fullUsers.map((user) => {
+                      const userName = `${user.name.first} ${user.name.last}`;
+                      if (
+                        userName !==
+                        `${userData.name.first} ${userData.name.last}`
+                      ) {
+                        return (
+                          <MenuItem
+                            className="cardFormValues"
+                            key={user._id}
+                            value={user._id}
+                          >
+                            {userName}
+                          </MenuItem>
+                        );
+                      }
+                      // If there is a match with the logged in user's name, it won't be rendered on the list
+                      return null;
+                    })}
                   </TextField>
                 </div>
                 <div className="formSelect">

--- a/src/components/Dashboard/DashboardHeader.jsx
+++ b/src/components/Dashboard/DashboardHeader.jsx
@@ -1,61 +1,17 @@
-import { Typography, Box, CircularProgress } from "@mui/material";
-import axios from "axios";
-import { useEffect, useState } from "react";
-import { fullUsersUrl } from "../../utils/ApiPaths";
+import { Typography, Box } from "@mui/material";
 
 export default function DashboardHeader() {
-  const userEmail = localStorage.getItem("loggedInEmail");
+  const userData = JSON.parse(localStorage.getItem("loggedInUser"));
 
-  // Establishing states
-  const [user, setUser] = useState([]);
-  const [loading, setLoading] = useState(true);
-
-  // Importing full users info
-  useEffect(() => {
-    const fetchFullUsers = async () => {
-      try {
-        // Retrieve JWT token from local storage
-        const jwtToken = localStorage.getItem("jwtToken");
-
-        // Include the token in the GET request headers
-        const response = await axios.get(fullUsersUrl, {
-          headers: {
-            Authorization: `Bearer ${jwtToken}`,
-          },
-        });
-        // TODO: convert userEmail to lowercase when comparing for edge cases
-        const matchingUser = response.data.Users.find(
-          (user) => user.email === userEmail
-        );
-        setUser(matchingUser);
-      } catch (error) {
-        console.error("Error fetching data:", error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchFullUsers();
-  }, [userEmail]);
-
-  // TODO: better loading experience
   return (
-    <div>
-      {loading ? (
-        <div className="loader">
-          <CircularProgress />
-        </div>
-      ) : (
-        <Box className="pageHeading">
-          <Typography component="h1" variant="h3">
-            Hi there, {user.name.first}!
-          </Typography>
-          <Typography component="subtitle1" variant="h6">
-            {/* TODO: have an assortments of greetings and render a random one each time */}
-            It's a good day to We'ppreciate ☀️
-          </Typography>
-        </Box>
-      )}
-    </div>
+    <Box className="pageHeading">
+      <Typography component="h1" variant="h3">
+        Hi there, {userData.name.first}!
+      </Typography>
+      <Typography component="subtitle1" variant="h6">
+        {/* TODO: have an assortments of greetings and render a random one each time */}
+        It's a good day to We'ppreciate ☀️
+      </Typography>
+    </Box>
   );
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,7 +1,7 @@
 // Purpose: logic and rendering for the header for the application once user is logged in
 // Modelled from AppBar MUI component
 
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Link } from "react-router-dom";
 import {
   AppBar,
@@ -19,8 +19,6 @@ import { styled } from "@mui/material/styles";
 import SearchIcon from "@mui/icons-material/Search";
 import DashboardPage from "../pages/DashboardPage";
 import { AccountCircle, Logout, Settings } from "@mui/icons-material";
-import axios from "axios";
-import { fullUsersUrl } from "../utils/ApiPaths";
 
 // Styling for Appbar
 // TODO - see if this can work in a separate file
@@ -62,36 +60,7 @@ const StyledInputBase = styled(InputBase)(({ theme }) => ({
 }));
 
 export default function Header() {
-  const userEmail = localStorage.getItem("loggedInEmail");
-
-  // Establishing states
-  const [user, setUser] = useState([]);
-
-  // Importing full users info
-  useEffect(() => {
-    const fetchFullUsers = async () => {
-      try {
-        // Retrieve JWT token from local storage
-        const jwtToken = localStorage.getItem("jwtToken");
-
-        // Include the token in the GET request headers
-        const response = await axios.get(fullUsersUrl, {
-          headers: {
-            Authorization: `Bearer ${jwtToken}`,
-          },
-        });
-        // TODO: convert userEmail to lowercase when comparing for edge cases
-        const matchingUser = response.data.Users.find(
-          (user) => user.email === userEmail
-        );
-        setUser(matchingUser);
-      } catch (error) {
-        console.error("Error fetching data:", error);
-      }
-    };
-
-    fetchFullUsers();
-  }, [userEmail]);
+  const userData = JSON.parse(localStorage.getItem("loggedInUser"));
 
   const [anchorEl, setAnchorEl] = React.useState(null);
 
@@ -126,7 +95,7 @@ export default function Header() {
       {/* TODO: need to update the styling on this menu and have other options show conditionally based on user role */}
 
       {/* Need to link to the own user's profile by fetching their id: */}
-      <Link to={"/profile/" + user._id} className="menu">
+      <Link to={"/profile/" + userData.id} className="menu">
         <MenuItem onClick={handleMenuClose}>
           <AccountCircle />
           <Typography className="menuItem">Profile</Typography>
@@ -182,7 +151,7 @@ export default function Header() {
             >
               {/* Need to adjust so this renders actual user photo and only uses base avatar if no photo is uploaded */}
 
-              <Avatar />
+              <Avatar alt={`${userData.name.first} ${userData.name.last}`} src={userData.userPhotoKey}/>
             </IconButton>
           </Box>
         </Toolbar>

--- a/src/components/Login/SignIn.jsx
+++ b/src/components/Login/SignIn.jsx
@@ -80,9 +80,10 @@ const SignIn = ({ setView }) => {
         return response.json();
       })
       .then((data) => {
-        // Stores the token and logged in user's email in local storage
+        console.log(data)
+        // Stores the token and logged in user's details in local storage
         localStorage.setItem("jwtToken", data.token);
-        localStorage.setItem("loggedInEmail", formData.email);
+        localStorage.setItem("loggedInUser", JSON.stringify(data));
 
         // Redirect to the Dashboard
         window.location.href = "/dashboard";

--- a/src/components/Profile/ProfileCard.jsx
+++ b/src/components/Profile/ProfileCard.jsx
@@ -14,7 +14,8 @@ export default function ProfileCard({ apiData }) {
       <Card className="profileCardHeader">
         <CardHeader
           className="profileCardHeader"
-          avatar={<Avatar />} // Need to link this to the user's avatar
+          // TODO: make this avatar larger!
+          avatar={<Avatar alt={`${firstName} ${lastName}`} src={apiData.userPhotoKey}/>}
         //   Note - need to add validation later to change this to edit a profile for own user
           title={`${firstName} ${lastName}`}
           subheader={apiData.businessUnit}


### PR DESCRIPTION
- updating local storage saved on response from login API request from Nate's backend update
- name on dashboard, user photo on header and user's ID for profile link all render from storage instead of API
- user's photo rendering on profile, or initial displayed if no photo
- the name of the logged in user is not an option in the send card drop-down